### PR TITLE
Fix issue #20

### DIFF
--- a/rockstar
+++ b/rockstar
@@ -1,3 +1,3 @@
 #!/bin/bash
-PATH_TO_ROCKY=`dirname $0`
+PATH_TO_ROCKY="$(dirname "$(readlink -f $0)")"
 java -classpath ${PATH_TO_ROCKY}/rocky.jar rockstar.Rockstar $*


### PR DESCRIPTION
This fix uses ```readlink -f```, which, although not POSIX compliant, should work on most OSes.