### PR TITLE
Make "in" an alias of "into"

### DIFF
--- a/src/rockstar/parser/Keyword.java
+++ b/src/rockstar/parser/Keyword.java
@@ -39,7 +39,7 @@ public enum Keyword {
     OVER(true, true, "over", "/"),
     ROCK(false, false),
     ROLL(true, true, "roll", "pop"),
-    INTO(true, true, "into"),
+    INTO(true, true, "into", "in"),
     FROM(false, true, "from"),
     TILL(false, true, "till"),
     TAKING(true, true, "taking"),

--- a/src/rockstar/parser/checker/RockChecker.java
+++ b/src/rockstar/parser/checker/RockChecker.java
@@ -20,7 +20,9 @@ public class RockChecker extends Checker<VariableReference, Expression, Object> 
         new ParamList("Rock", variableAt(1), "with", expressionAt(2)),
         new ParamList("Push", variableAt(1), "with", expressionAt(2)),
         new ParamList("Rock", expressionAt(2), "into", variableAt(1)),
-        new ParamList("Push", expressionAt(2), "into", variableAt(1))};
+        new ParamList("Rock", expressionAt(2), "in", variableAt(1)),
+        new ParamList("Push", expressionAt(2), "into", variableAt(1)),
+        new ParamList("Push", expressionAt(2), "in", variableAt(1))};
 
     @Override
     public Statement check() {

--- a/src/rockstar/parser/checker/RollChecker.java
+++ b/src/rockstar/parser/checker/RollChecker.java
@@ -17,7 +17,9 @@ public class RollChecker extends Checker<VariableReference, VariableReference, O
 
     private static final ParamList[] PARAM_LIST = new ParamList[]{
         new ParamList("Roll", variableAt(2), "into", variableAt(1)),
+        new ParamList("Roll", variableAt(2), "in", variableAt(1)),
         new ParamList("Pop", variableAt(2), "into", variableAt(1)),
+        new ParamList("Pop", variableAt(2), "in", variableAt(1)),
         new ParamList("Pull", variableAt(1), "from", variableAt(2))};
 
     @Override


### PR DESCRIPTION
Background: In RockstarLang/rockstar#280, I clarified that `in` was an alias for `into`. It had already been implemented that way in the reference implementation in all but one case.

This PR doesn't make `in` work universally yet. For example, `cast first in second` fails to parse. From my debugging, I think `first in second` is matching `Keyword.ON` for a [Rocky OOP method call](https://github.com/gaborsch/rocky/blob/master/OOP.md#method-call). I'm not sure whether Rocky can distinguish between the two or whether `in` will need to be removed from the `on` alias list.