### PR TITLE
Get poetic literal position from token list

### DIFF
--- a/src/rockstar/parser/checker/Checker.java
+++ b/src/rockstar/parser/checker/Checker.java
@@ -144,29 +144,10 @@ public abstract class Checker<T1, T2, T3> {
         boolean validText = false;
         Expression e = null;
         if (ph.getType() == POETIC_LITERAL) {
-            String assignmentToken = line.getTokens().get(lastPos).getValue();
             String orig = line.getOrigLine();
-            int p = orig.indexOf(" " + assignmentToken + " ");
-            if (assignmentToken.equals("is")) {
-                // maybe "'s" was expanded to " is "
-                int p2 = orig.indexOf("'s "); 
-                // find out which one was the first, "is" or "'s"
-                p = (p2 < 0) ? p : ((p < 0) ? p2 : ((p < p2) ? p : p2));
-                if (p >= 0) {
-                   if (p == p2) {
-                        p = p + "'s ".length();
-                    } else {
-                        p = p + assignmentToken.length() + 2;
-                    }
-                }
-            } else {
-                p += assignmentToken.length() + 2;
-            }
-            if (p >= 0) {
-                String origEnd = orig.substring(p);
-                e = ExpressionFactory.getPoeticLiteralFor(posTokens, line, origEnd, block);
-                validExpr = true;
-            }
+            String origEnd = orig.substring(line.getTokens().get(lastPos+1).getPos());
+            e = ExpressionFactory.getPoeticLiteralFor(posTokens, line, origEnd, block);
+            validExpr = true;
             
         } else {
             // default expression may be defined - hopefully it has already been parsed


### PR DESCRIPTION
This fixes problems assigning with `'re`:

```console
$ cat are.rock
rocky is great
say it
rocky's great
say it

you are great
say it
you're great
say it

$ ./rockstar are.rock
5
5
5
25
```

@gaborsch I'm not sure whether this needs more bounds-checking. For example, can `get(lastPos+1)` fail, or is that necessarily present before this code runs?