### PR TITLE
Fix docker mount using $(pwd) instead of ${pwd}

### DIFF
--- a/dockstar
+++ b/dockstar
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker run -it -v ${pwd}:/local -w="/local" java:8-jdk-alpine java -classpath rocky.jar rockstar.Rockstar $*
+docker run -it -v "$(pwd):/local" -w="/local" java:8-jdk-alpine java -classpath rocky.jar rockstar.Rockstar $*


### PR DESCRIPTION
Closes #31

Fix docker mount using $(pwd) instead of ${pwd}