### PR TITLE
Match verb case-insensitively in poetic string assignment

### DIFF
--- a/src/rockstar/parser/checker/PoeticStringAssignmentChecker.java
+++ b/src/rockstar/parser/checker/PoeticStringAssignmentChecker.java
@@ -8,6 +8,7 @@ package rockstar.parser.checker;
 import java.util.List;
 import rockstar.expression.ConstantExpression;
 import rockstar.expression.VariableReference;
+import rockstar.parser.Token;
 import rockstar.statement.AssignmentStatement;
 import rockstar.statement.Statement;
 
@@ -30,8 +31,13 @@ public class PoeticStringAssignmentChecker extends Checker<VariableReference, Li
     private Statement validate(ParamList params) {
         VariableReference varRef = getE1();
         String verb = ((List<String>) params.getParams()[1]).get(0);
-        // grab original string from line, skip param 2
-        String poeticLiteralString = line.getOrigLine().substring(line.getOrigLine().indexOf(verb + " ") + verb.length() + 1);
+        String poeticLiteralString = "";
+        for (Token token : line.getTokens()) {
+            if (token.getValue().toLowerCase().equals(verb)) {
+                poeticLiteralString = line.getOrigLine().substring(token.getPos() + token.getLen() + 1);
+                break;
+            }
+        }
         ConstantExpression value = new ConstantExpression(poeticLiteralString);
         return new AssignmentStatement(varRef, value);
     }


### PR DESCRIPTION
The existing code looked for the lowercase version of the verb, but doesn't find it if the original verb was not completely lowercase, so the content substring would start at `-1 + verb.length() + 1` (either 3 or 4, depending on the verb).

```
> Rocky Says Hello
> say it
y Says Hello
> Rocky Say Hello
> say it
ky Say Hello
```

After this change, we can successfully locate non-lowercase verbs, and the substring extraction works correctly:

```
> Rocky Says Hello
> say it
Hello
> Rocky Say Hello
> say it
Hello
```