### PR TITLE
Use /usr/bin/env as shebang

### DIFF
--- a/rockstar
+++ b/rockstar
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 PATH_TO_ROCKY="$(dirname "$(readlink -f $0)")"
 java -classpath ${PATH_TO_ROCKY}/rocky.jar rockstar.Rockstar $*


### PR DESCRIPTION
Use `!/usr/bin/env bash`  as shebang, because not all operating systems (e.g. guix) have `bash` at `/bin/bash`.

Vice-versa, not every operating system has `env` at `/usr/bin/env` either (e.g. some BSDs), so it is a bit of a pick your poison situation.
